### PR TITLE
Show orientation on minimap

### DIFF
--- a/game.py
+++ b/game.py
@@ -35,8 +35,9 @@ def draw_scene(stdscr, game_map: Map, player: Player):
             else:
                 stdscr.addch(sy, sx, ord(' '), curses.color_pair(5))
 
-    # draw player ship as blue triangle near bottom center
-    stdscr.addch(height - 2, width // 2, ord('^'), curses.color_pair(2))
+    # draw player ship near bottom center showing orientation
+    ship_char = player.direction_arrow()
+    stdscr.addch(height - 2, width // 2, ord(ship_char), curses.color_pair(2))
 
     # draw minimap in the top-left corner
     mini_h = min(game_map.height, MINIMAP_MAX_SIZE)
@@ -57,7 +58,7 @@ def draw_scene(stdscr, game_map: Map, player: Player):
                 color = curses.color_pair(4)
             draw_char = char
             if int(player.x) == mx and int(player.y) == my:
-                draw_char = '^'
+                draw_char = player.direction_arrow()
                 color = curses.color_pair(2)
             stdscr.addch(my, mx, ord(draw_char), color)
 

--- a/player.py
+++ b/player.py
@@ -16,6 +16,18 @@ class Player:
         self.health = health
         self._boost_frames = 0
 
+    def direction_arrow(self) -> str:
+        """Return an ASCII arrow representing the facing direction."""
+        angle = self.angle % (2 * math.pi)
+        if angle < math.pi / 4 or angle >= 7 * math.pi / 4:
+            return '^'
+        elif angle < 3 * math.pi / 4:
+            return '>'
+        elif angle < 5 * math.pi / 4:
+            return 'v'
+        else:
+            return '<'
+
     def turn_left(self):
         self.angle -= 0.1
 

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from map_loader import Map
 from player import Player
 import game
+import math
 
 
 class DummyScreen:
@@ -50,6 +51,17 @@ class PlayerTests(unittest.TestCase):
         p.throttle = False
         p.update()
         self.assertLessEqual(p.speed, 1.0)
+
+    def test_direction_arrow(self):
+        p = Player()
+        p.angle = 0.0
+        self.assertEqual(p.direction_arrow(), '^')
+        p.angle = math.pi / 2
+        self.assertEqual(p.direction_arrow(), '>')
+        p.angle = math.pi
+        self.assertEqual(p.direction_arrow(), 'v')
+        p.angle = 3 * math.pi / 2
+        self.assertEqual(p.direction_arrow(), '<')
 
 
 class TrackTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add `direction_arrow` helper to Player
- draw player facing direction on screen and minimap
- test orientation arrow logic

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68620a42ee04833189aa0a68d6c29887