### PR TITLE
Fix NameError and add jumping + AI opponent

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -1,0 +1,36 @@
+from player import Player
+import math
+
+class AIPlayer(Player):
+    """Simple AI driver that follows the track."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.throttle = True
+
+    def update_ai(self, game_map):
+        # Look ahead and steer away from walls
+        look_dist = 2.0
+        front_x = self.x + math.sin(self.angle) * look_dist
+        front_y = self.y - math.cos(self.angle) * look_dist
+        front = game_map.char_at(front_x / 4.0, front_y / 4.0)
+        if front == 'o':
+            # try turning
+            left_a = self.angle - 0.4
+            left_x = self.x + math.sin(left_a) * look_dist
+            left_y = self.y - math.cos(left_a) * look_dist
+            right_a = self.angle + 0.4
+            right_x = self.x + math.sin(right_a) * look_dist
+            right_y = self.y - math.cos(right_a) * look_dist
+            left = game_map.char_at(left_x / 4.0, left_y / 4.0)
+            right = game_map.char_at(right_x / 4.0, right_y / 4.0)
+            if left != 'o':
+                self.turn_left()
+            elif right != 'o':
+                self.turn_right()
+            else:
+                self.turn_left()
+        else:
+            # small random jitter to simulate steering
+            pass
+        super().update()
+

--- a/player.py
+++ b/player.py
@@ -7,6 +7,8 @@ class Player:
     BASE_ACCEL = 0.02
     BOOST_ACCEL = 0.05
     BOOST_DURATION = 20  # frames
+    GRAVITY = -0.08
+    JUMP_VELOCITY = 1.2
 
     def __init__(self, x: float = 1.0, y: float = 1.0, health: int = 100):
         self.x = x
@@ -22,6 +24,9 @@ class Player:
         self.best_lap = None
         self._lap_start = time.time()
         self.start_time = time.time()
+        self.z = 0.0
+        self.z_speed = 0.0
+        self._z_input = 0.0
 
     def direction_arrow(self) -> str:
         """Return an ASCII arrow representing the facing direction."""
@@ -66,6 +71,17 @@ class Player:
         self.x += math.sin(self.angle) * self.speed
         self.y -= math.cos(self.angle) * self.speed
 
+        # vertical physics
+        if self.z > 0 or self.z_speed > 0:
+            self.z_speed += self.GRAVITY
+        if self._z_input != 0 and self.z > 0:
+            self.z_speed += self._z_input * 0.05
+        self.z += self.z_speed
+        if self.z <= 0:
+            self.z = 0
+            self.z_speed = 0
+        self._z_input = 0.0
+
     def start_boost(self):
         if self._boost_frames > 0:
             return
@@ -80,6 +96,14 @@ class Player:
         else:
             self._boost_frames = self.BOOST_DURATION
             self.health -= cost
+
+    def jump(self):
+        if self.z == 0:
+            self.z_speed = self.JUMP_VELOCITY
+
+    def vertical_input(self, direction: float):
+        """direction >0 to rise, <0 to fall faster"""
+        self._z_input = direction
 
     @property
     def boosting(self) -> bool:


### PR DESCRIPTION
## Summary
- fix missing `enter_fullscreen`/`exit_fullscreen`
- support jumping with `J` pads and vertical control with arrow keys
- basic AI opponent that drives around the map
- render AI on screen and show jump height

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862227141d48331bbd858c051ee61e5